### PR TITLE
H5F (feat) - Implementa Busca de Mentores com Filtros, Ordenação, Guard e Testes

### DIFF
--- a/frontend/mentoria-agil/src/app/auth/auth.guard.ts
+++ b/frontend/mentoria-agil/src/app/auth/auth.guard.ts
@@ -1,0 +1,27 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, ActivatedRouteSnapshot } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
+
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
+  }
+
+  const allowedRoles = route.data?.['roles'] as string[] | undefined;
+
+  if (allowedRoles && allowedRoles.length > 0) {
+    const hasPermission = allowedRoles.some(role =>
+      authService.hasRole(role)
+    );
+
+    if (!hasPermission) {
+      return router.createUrlTree(['/forbidden']);
+    }
+  }
+
+  return true;
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -548,6 +548,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.1.2.tgz",
       "integrity": "sha512-NK26OG1+/3EXLDWstSPmdGbkpt8bP9AsT9J7EBornMswUjmQDbjyb85N/esKjRjDMkw4p/aKpBo24eCV5uUmBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -564,6 +565,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.1.2.tgz",
       "integrity": "sha512-5OFdZPNix7iK4HSdRxPgg74VvcmQZAMzv9ACYZ8iGfNxiJUjFSurfz0AtVEh0oE2oZDH1v48bHI1s+0ljCHZhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -577,6 +579,7 @@
       "integrity": "sha512-h+sX7QvSz58KvmRwNMa33EZHti8Cnw1DL01kInJ/foDchC/O2VMOumeGHS+lAe48t2Nbhiq/obgf275TkDZYsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.5",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -609,6 +612,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.1.2.tgz",
       "integrity": "sha512-W2xxRb7noOD1DdMwKaZ3chFhii6nutaNIXt7dfWsMWoujg3Kqpdn1ukeyW5aHKQZvCJTIGr4f3whZ8Sj/17aCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -653,6 +657,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.1.2.tgz",
       "integrity": "sha512-8vnCbQhxugQ3meGQ0YlSp0uNBYUjpFXYjFnGQ0Xq5jvzc9WX7KSix6+AydEjZtQfc1bWRetBTOlhQpqnwYp53g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -774,6 +779,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1124,6 +1130,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1164,6 +1171,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1907,6 +1915,7 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -4628,6 +4637,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4776,6 +4786,7 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -5490,6 +5501,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5817,6 +5829,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6184,6 +6197,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -6536,6 +6550,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -7878,6 +7893,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8530,7 +8546,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -8567,6 +8584,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8687,6 +8705,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8762,6 +8781,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -9159,6 +9179,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { AuthGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
   { 
@@ -38,6 +39,14 @@ export const routes: Routes = [
         loadComponent: () => import('./views/dashboard/Dashboard')
         .then(m => m.Dashboard)
       },
+
+ {
+  path: 'mentores',
+  loadComponent: () =>
+    import('./views/mentores/mentor-list.component')
+      .then(m => m.MentorListComponent),
+  canActivate: [AuthGuard]
+},
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
     ]
   },

--- a/frontend/src/app/auth/auth.guard.ts
+++ b/frontend/src/app/auth/auth.guard.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, ActivatedRouteSnapshot } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const AuthGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
+
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    console.warn('Usuário não autenticado. Redirecionando para /login');
+    return router.createUrlTree(['/login']);
+  }
+
+  const requiredRole = route.data?.['role'] as 'ADMIN' | 'USER' | undefined;
+
+  if (requiredRole && !authService.hasRole(requiredRole)) {
+    console.warn('Usuário não possui permissão suficiente.');
+    return router.createUrlTree(['/unauthorized']);
+  }
+
+  return true;
+};

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -36,8 +36,17 @@ export class AuthService {
   }
 
   isAuthenticated(): boolean {
-    return !!this.getToken();
+  const token = this.getToken();
+  if (!token) return false;
+
+  try {
+    const decoded: any = jwtDecode(token);
+    const isExpired = decoded.exp * 1000 < Date.now();
+    return !isExpired;
+  } catch {
+    return false;
   }
+}
 
   hasRole(role: 'ADMIN' | 'USER'): boolean {
     const user = this.currentUserSubject.value;

--- a/frontend/src/app/models/PerfilMentor.ts
+++ b/frontend/src/app/models/PerfilMentor.ts
@@ -1,0 +1,10 @@
+export interface PerfilMentor {
+  id: number;
+  name: string;
+  especializacao: string;
+  experiencias: string;
+  areaPrincipal: string;
+  tipoMentoria: 'ACADEMICA' | 'PROFISSIONAL' | 'AMBAS';
+  disponibilidade: 'DISPONIVEL' | 'OCUPADO';
+  ativo: boolean;
+}

--- a/frontend/src/app/services/perfil-mentor.service.spec.ts
+++ b/frontend/src/app/services/perfil-mentor.service.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PerfilMentorService } from './perfil-mentor.service';
+
+describe('PerfilMentorService', () => {
+
+  let service: PerfilMentorService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+
+    service = TestBed.inject(PerfilMentorService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('deve montar URL com parâmetros corretamente', () => {
+
+    service.buscarMentores({
+      areaPrincipal: 'TI',
+      tipoMentoria: 'ACADEMICA'
+    }).subscribe();
+
+    const req = httpMock.expectOne(req =>
+      req.url.includes('/api/mentors') &&
+      req.params.get('areaPrincipal') === 'TI' &&
+      req.params.get('tipoMentoria') === 'ACADEMICA'
+    );
+
+    expect(req.request.method).toBe('GET');
+  });
+
+});

--- a/frontend/src/app/services/perfil-mentor.service.ts
+++ b/frontend/src/app/services/perfil-mentor.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { PerfilMentor } from '../models/PerfilMentor';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PerfilMentorService {
+
+  private apiUrl = 'http://localhost:8080/api/mentors';
+
+  constructor(private http: HttpClient) {}
+
+  buscarMentores(filtros: any): Observable<PerfilMentor[]> {
+
+    let params = new HttpParams();
+
+    Object.keys(filtros).forEach(key => {
+      if (filtros[key]) {
+        params = params.set(key, filtros[key]);
+      }
+    });
+
+    return this.http.get<PerfilMentor[]>(this.apiUrl, { params });
+  }
+}

--- a/frontend/src/app/views/mentores/mentor-list.component.css
+++ b/frontend/src/app/views/mentores/mentor-list.component.css
@@ -1,0 +1,19 @@
+.filtros {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+select {
+  padding: 6px;
+  border-radius: 6px;
+}
+
+.mentor-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 12px;
+  background-color: #f5f5f5;
+  box-shadow: 2px 2px 8px rgba(0,0,0,0.08);
+}

--- a/frontend/src/app/views/mentores/mentor-list.component.html
+++ b/frontend/src/app/views/mentores/mentor-list.component.html
@@ -1,0 +1,40 @@
+<h2>Mentores Disponíveis</h2>
+
+<div class="filtros">
+
+  <select [(ngModel)]="filtros.areaPrincipal" (change)="onFiltroChange()">
+    <option value="">Área</option>
+    <option value="TI">TI</option>
+    <option value="SAUDE">Saúde</option>
+  </select>
+
+  <select [(ngModel)]="filtros.tipoMentoria" (change)="onFiltroChange()">
+    <option value="">Tipo</option>
+    <option value="ACADEMICA">Acadêmica</option>
+    <option value="PROFISSIONAL">Profissional</option>
+    <option value="AMBAS">Ambas</option>
+  </select>
+
+  <select [(ngModel)]="filtros.disponibilidade" (change)="onFiltroChange()">
+    <option value="">Disponibilidade</option>
+    <option value="DISPONIVEL">Disponível</option>
+    <option value="OCUPADO">Ocupado</option>
+  </select>
+
+  <select [(ngModel)]="filtros.ordenacao" (change)="onFiltroChange()">
+    <option value="">Ordenar</option>
+    <option value="nome">Ordem Alfabética</option>
+  </select>
+
+</div>
+
+<div *ngFor="let mentor of mentores" class="mentor-card">
+
+  <h3>{{ mentor.name }}</h3>
+  <p><strong>Especialização:</strong> {{ mentor.especializacao }}</p>
+  <p><strong>Resumo:</strong> {{ mentor.experiencias }}</p>
+  <p><strong>Área Principal:</strong> {{ mentor.areaPrincipal }}</p>
+  <p><strong>Tipo:</strong> {{ mentor.tipoMentoria }}</p>
+  <p><strong>Disponibilidade:</strong> {{ mentor.disponibilidade }}</p>
+
+</div>

--- a/frontend/src/app/views/mentores/mentor-list.component.spec.ts
+++ b/frontend/src/app/views/mentores/mentor-list.component.spec.ts
@@ -1,0 +1,56 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MentorListComponent } from './mentor-list.component';
+import { PerfilMentorService } from '../../services/perfil-mentor.service';
+import { of } from 'rxjs';
+
+describe('MentorListComponent', () => {
+
+  let component: MentorListComponent;
+  let fixture: ComponentFixture<MentorListComponent>;
+
+  const mockService = {
+    buscarMentores: jasmine.createSpy().and.returnValue(of([
+      {
+        id: 1,
+        name: 'Carlos',
+        especializacao: 'TI',
+        experiencias: '5 anos',
+        areaPrincipal: 'TI',
+        tipoMentoria: 'ACADEMICA',
+        disponibilidade: 'DISPONIVEL',
+        ativo: true
+      },
+      {
+        id: 2,
+        name: 'Ana',
+        especializacao: 'Saúde',
+        experiencias: '10 anos',
+        areaPrincipal: 'SAUDE',
+        tipoMentoria: 'PROFISSIONAL',
+        disponibilidade: 'DISPONIVEL',
+        ativo: true
+      }
+    ]))
+  };
+
+  beforeEach(async () => {
+
+    await TestBed.configureTestingModule({
+      imports: [MentorListComponent],
+      providers: [
+        { provide: PerfilMentorService, useValue: mockService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MentorListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('deve renderizar 2 cards de mentores', () => {
+    const compiled = fixture.nativeElement;
+    const cards = compiled.querySelectorAll('.mentor-card');
+    expect(cards.length).toBe(2);
+  });
+
+});

--- a/frontend/src/app/views/mentores/mentor-list.component.ts
+++ b/frontend/src/app/views/mentores/mentor-list.component.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from '@angular/core';
+import { PerfilMentorService } from '../../services/perfil-mentor.service';
+import { PerfilMentor } from '../../models/PerfilMentor';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-mentor-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './mentor-list.component.html',
+  styleUrls: ['./mentor-list.component.css']
+})
+export class MentorListComponent implements OnInit {
+
+  mentores: PerfilMentor[] = [];
+
+  filtros = {
+    areaPrincipal: '',
+    tipoMentoria: '',
+    disponibilidade: '',
+    ordenacao: ''
+  };
+
+  constructor(private mentorService: PerfilMentorService) {}
+
+  ngOnInit(): void {
+    this.buscar();
+  }
+
+  buscar() {
+    this.mentorService.buscarMentores(this.filtros)
+      .subscribe(data => {
+
+        let lista = data.filter(m => m.ativo);
+
+        if (this.filtros.ordenacao === 'nome') {
+          lista = lista.sort((a, b) => a.name.localeCompare(b.name));
+        }
+
+        this.mentores = lista;
+      });
+  }
+
+  onFiltroChange() {
+    this.buscar();
+  }
+}


### PR DESCRIPTION
📝 Descrição

Este PR implementa a funcionalidade completa de busca, filtragem e listagem de mentores disponíveis (H5), incluindo:
- Componente visual de listagem com estilização customizada
- Sistema de filtros dinâmicos
- Ordenação por critério selecionado
- Proteção de rota com AuthGuard
- Testes unitários para componente e serviço
A implementação segue boas práticas do Angular 19, utilizando componentes standalone, separação em camadas (model, service, view) e controle de acesso via Guard.

🔗 Issue Relacionada

Fixes #59 #60 #61 #62

🧪 Como testar?

🔹 Teste manual

1. Faça checkout para esta branch.
2. Rode:
npm install
npm start

3. Acesse:
http://localhost:4200/mentores

4. Verifique se:
- A listagem de mentores é exibida corretamente.
- Apenas mentores com perfil ativo aparecem.
- Os filtros (Área, Tipo e Disponibilidade) atualizam a lista automaticamente.
- A ordenação alfabética funciona corretamente.

5. Remova o token do localStorage e tente acessar /mentores.
- O sistema deve redirecionar automaticamente para /login.

🔹 Testes automatizados

1. Rode:
npm test

2. Verifique se:
- O teste do PerfilMentorService valida corretamente a montagem da URL com parâmetros.
- O teste do MentorListComponent confirma a renderização correta da quantidade de cards com base no mock.
- Todos os testes estão passando sem erros.