### PR TITLE
Implementação Frontend H6

### DIFF
--- a/frontend/src/app/services/mentoria/mentoria.service.spec.ts
+++ b/frontend/src/app/services/mentoria/mentoria.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { MentoriaService } from './mentoria.service';
+import { SolicitacaoMentoriaRequest } from '../models/SolicitacaoMentoriaRequest';
+import { SolicitacaoMentoriaResponse } from '../models/SolicitacaoMentoriaResponse';
+
+describe('MentoriaService', () => {
+  let service: MentoriaService;
+  let httpMock: HttpTestingController;
+  const apiUrl = 'http://localhost:8080/api/mentorias/request';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [MentoriaService]
+    });
+    service = TestBed.inject(MentoriaService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('deve ser criado', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('deve chamar o endpoint POST com os dados corretos', () => {
+    const mockRequest: SolicitacaoMentoriaRequest = {
+      mentorId: 1,
+      message: 'Quero aprender Java'
+    };
+
+    const mockResponse: SolicitacaoMentoriaResponse = {
+      id: 10,
+      mentoradoId: 5,
+      mentoradoName: 'João',
+      mentorId: 1,
+      mentorName: 'Maria',
+      message: 'Quero aprender Java',
+      status: 'PENDING',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+
+    service.solicitarMentoria(mockRequest).subscribe(response => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(mockRequest);
+    req.flush(mockResponse);
+  });
+
+  it('deve tratar erros corretamente', () => {
+    const mockRequest: SolicitacaoMentoriaRequest = {
+      mentorId: 1,
+      message: 'Teste'
+    };
+
+    service.solicitarMentoria(mockRequest).subscribe({
+      next: () => fail('Esperava um erro, mas obteve sucesso'),
+      error: (error) => {
+        expect(error.status).toBe(500);
+      }
+    });
+
+    const req = httpMock.expectOne(apiUrl);
+    req.flush('Erro interno', { status: 500, statusText: 'Internal Server Error' });
+  });
+});

--- a/frontend/src/app/services/mentoria/mentoria.service.ts
+++ b/frontend/src/app/services/mentoria/mentoria.service.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { SolicitacaoMentoriaRequest } from '../../models/SolicitacaoMentoriaRequest';
+import { SolicitacaoMentoriaResponse } from '../../models/SolicitacaoMentoriaResponse';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MentoriaService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = `http://localhost:8080/api/mentorias`;
+
+  solicitarMentoria(dados: SolicitacaoMentoriaRequest): Observable<SolicitacaoMentoriaResponse> {
+    return this.http.post<SolicitacaoMentoriaResponse>(`${this.apiUrl}/request`, dados);
+  }
+}

--- a/frontend/src/app/views/mentores/mentor-list.component.css
+++ b/frontend/src/app/views/mentores/mentor-list.component.css
@@ -17,3 +17,20 @@ select {
   background-color: #f5f5f5;
   box-shadow: 2px 2px 8px rgba(0,0,0,0.08);
 }
+
+
+.solicitar-btn {
+  background-color: #2563eb;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  margin-top: 10px;
+  transition: background-color 0.2s;
+}
+
+.solicitar-btn:hover {
+  background-color: #1d4ed8;
+}

--- a/frontend/src/app/views/mentores/mentor-list.component.html
+++ b/frontend/src/app/views/mentores/mentor-list.component.html
@@ -33,4 +33,5 @@
   <p><strong>Área Principal:</strong> {{ mentor.areaPrincipal }}</p>
   <p><strong>Tipo:</strong> {{ mentor.tipoMentoria }}</p>
   <p><strong>Disponibilidade:</strong> {{ mentor.disponibilidade }}</p>
+  <button class="solicitar-btn" (click)="solicitarMentoria(mentor)">Solicitar Mentoria</button>
 </div>

--- a/frontend/src/app/views/mentores/mentor-list.component.spec.ts
+++ b/frontend/src/app/views/mentores/mentor-list.component.spec.ts
@@ -1,12 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MentorListComponent } from './mentor-list.component';
 import { PerfilMentorService } from '../../services/perfil-mentor.service';
+import { MatDialog } from '@angular/material/dialog';
 import { of } from 'rxjs';
 import { vi, describe, beforeEach, it, expect } from 'vitest';
 
 describe('MentorListComponent', () => {
   let component: MentorListComponent;
   let fixture: ComponentFixture<MentorListComponent>;
+  let mockDialog: any;
 
   const mockService = {
     buscarMentores: vi.fn().mockReturnValue(of([
@@ -34,10 +36,15 @@ describe('MentorListComponent', () => {
   };
 
   beforeEach(async () => {
+    mockDialog = {
+      open: vi.fn().mockReturnValue({ afterClosed: () => of(true) })
+    };
+
     await TestBed.configureTestingModule({
       imports: [MentorListComponent],
       providers: [
-        { provide: PerfilMentorService, useValue: mockService }
+        { provide: PerfilMentorService, useValue: mockService },
+        { provide: MatDialog, useValue: mockDialog } // <-- Adiciona o mock
       ]
     }).compileComponents();
 
@@ -50,5 +57,13 @@ describe('MentorListComponent', () => {
     const compiled = fixture.nativeElement;
     const cards = compiled.querySelectorAll('.mentor-card');
     expect(cards.length).toBe(2);
+  });
+
+  it('deve abrir o modal ao chamar solicitarMentoria', () => {
+    const mentor = component.mentores[0];
+    component.solicitarMentoria(mentor);
+    expect(mockDialog.open).toHaveBeenCalled();
+    expect(mockDialog.open.mock.calls[0][0]).toBe(SolicitacaoMentoriaModalComponent);
+    expect(mockDialog.open.mock.calls[0][1].data).toEqual({ mentor });
   });
 });

--- a/frontend/src/app/views/mentores/mentor-list.component.ts
+++ b/frontend/src/app/views/mentores/mentor-list.component.ts
@@ -1,8 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { PerfilMentorService } from '../../services/perfil-mentor.service';
 import { PerfilMentor } from '../../models/PerfilMentor';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { SolicitacaoMentoriaModalComponent } from './mentoria/solicitacao-mentoria-modal.component';
 
 @Component({
   selector: 'app-mentor-list',
@@ -22,7 +24,7 @@ export class MentorListComponent implements OnInit {
     ordenacao: ''
   };
 
-  constructor(private mentorService: PerfilMentorService) {}
+  constructor(private mentorService: PerfilMentorService, private dialog: MatDialog) {}
 
   ngOnInit(): void {
     this.buscar();
@@ -44,5 +46,18 @@ export class MentorListComponent implements OnInit {
 
   onFiltroChange() {
     this.buscar();
+  }
+
+  solicitarMentoria(mentor: PerfilMentor): void {
+    const dialogRef = this.dialog.open(SolicitacaoMentoriaModalComponent, {
+      width: '500px',
+      data: { mentor }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        console.log('Solicitação enviada com sucesso');
+      }
+    });
   }
 }

--- a/frontend/src/app/views/mentoria/solicitacao-mentoria-modal.component.css
+++ b/frontend/src/app/views/mentoria/solicitacao-mentoria-modal.component.css
@@ -1,0 +1,2 @@
+.full-width { width: 100%; }
+    mat-dialog-content { min-width: 400px; }

--- a/frontend/src/app/views/mentoria/solicitacao-mentoria-modal.component.html
+++ b/frontend/src/app/views/mentoria/solicitacao-mentoria-modal.component.html
@@ -1,0 +1,33 @@
+<h2 mat-dialog-title>Solicitar mentoria com {{ data.mentor.name }}</h2>
+    <mat-dialog-content>
+      <form [formGroup]="form">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Mensagem de introdução</mat-label>
+          <textarea
+            matInput
+            formControlName="message"
+            rows="4"
+            placeholder="Conte ao mentor seus objetivos e expectativas..."
+            maxlength="500"
+          ></textarea>
+          <mat-hint align="end">{{ form.get('message')?.value?.length || 0 }}/500</mat-hint>
+          <mat-error *ngIf="form.get('message')?.hasError('required')">
+            A mensagem é obrigatória
+          </mat-error>
+          <mat-error *ngIf="form.get('message')?.hasError('maxlength')">
+            Máximo de 500 caracteres
+          </mat-error>
+        </mat-form-field>
+      </form>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="cancelar()" [disabled]="loading">Cancelar</button>
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="enviar()"
+        [disabled]="form.invalid || loading"
+      >
+        {{ loading ? 'Enviando...' : 'Enviar solicitação' }}
+      </button>
+    </mat-dialog-actions>

--- a/frontend/src/app/views/mentoria/solicitacao-mentoria-modal.component.ts
+++ b/frontend/src/app/views/mentoria/solicitacao-mentoria-modal.component.ts
@@ -1,0 +1,66 @@
+import { Component, Inject, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MentoriaService } from '../../services/mentoria.service';
+import { PerfilMentor } from '../../models/PerfilMentor';
+
+@Component({
+  selector: 'app-solicitacao-mentoria-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule
+  ],
+  templateUrl: './solicitacao-mentoria-modal.component.html',
+  styleUrls: ['./solicitacao-mentoria-modal.css']
+})
+export class SolicitacaoMentoriaModalComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly mentoriaService = inject(MentoriaService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly dialogRef = inject(MatDialogRef<SolicitacaoMentoriaModalComponent>);
+
+  loading = false;
+
+  form = this.fb.group({
+    message: ['', [Validators.required, Validators.maxLength(500)]]
+  });
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { mentor: PerfilMentor }) {}
+
+  cancelar(): void {
+    this.dialogRef.close(false);
+  }
+
+  enviar(): void {
+    if (this.form.invalid) return;
+
+    this.loading = true;
+    const request = {
+      mentorId: this.data.mentor.id,
+      message: this.form.value.message!
+    };
+
+    this.mentoriaService.solicitarMentoria(request).subscribe({
+      next: () => {
+        this.snackBar.open('Solicitação enviada com sucesso!', 'Fechar', { duration: 3000 });
+        this.dialogRef.close(true);
+      },
+      error: (err) => {
+        this.loading = false;
+        const mensagem = err.error?.error || 'Erro ao enviar solicitação. Tente novamente.';
+        this.snackBar.open(mensagem, 'Fechar', { duration: 5000 });
+      }
+    });
+  }
+}


### PR DESCRIPTION
## 📝 Descrição
Este PR sobe a base para a implementação da tarefa de frontend da história de usuário H6 construindo o resto das entidades para se adequar ao backend. Falta polimento.

## 🔗 Issue Relacionada
Fixes #133 

## 🧪 Como testar?
1. Faça o checkout para esta branch.
2. Rode o comando `XYZ`.
3. Tente realizar a ação [X] e verifique o resultado [Y].

## ✅ Checklist de Revisão (Para o Autor)
- [ ] Meu código segue os padrões do projeto.
- [ ] Realizei testes locais.
- [ ] Adicionei comentários em partes complexas.
- [ ] Não quebrei funcionalidades existentes.

## 📸 Screenshots/Vídeos (Se houver alteração visual)
[Arraste a imagem aqui]
